### PR TITLE
Exit with non-zero status on error

### DIFF
--- a/src/syntaxerl.erl
+++ b/src/syntaxerl.erl
@@ -41,6 +41,7 @@ main(_) ->
 %% Internal
 %% ===================================================================
 
+-spec check_syntax(string(), boolean()) -> no_return().
 check_syntax(FileName, Debug) ->
     ScriptName = escript:script_name(),
     HandlerPatterns = handler_patterns(ScriptName),
@@ -66,7 +67,8 @@ usage() ->
             io:format("~n")
     end,
     io:format("  -d, --debug    Enable debug output~n"),
-    io:format("  -h, --help     Show this message~n~n").
+    io:format("  -h, --help     Show this message~n~n"),
+    halt(1).
 
 script_options(ScriptName) ->
     {ok, Sections} = escript:extract(ScriptName, []),

--- a/src/syntaxerl_utils.erl
+++ b/src/syntaxerl_utils.erl
@@ -68,19 +68,27 @@ deps_opts(BaseDir, OtpStdDirs, ErlcStdOpts) ->
 error_description(Error) ->
     tl(lists:dropwhile(fun(C) -> C =/= 32 end, file:format_error(Error))).
 
--spec print_issues(FileName::file:filename(), Issues::[issue()]) -> ok.
-print_issues(_FileName, []) ->
-    ok;
-print_issues(FileName, [Issue | Issues]) ->
-    print_issue(FileName, Issue),
-    print_issues(FileName, Issues).
+-spec print_issues(FileName::file:filename(), Issues::[issue()]) -> no_return().
+print_issues(FileName, Issues) ->
+    print_issues(FileName, Issues, 0).
+
+print_issues(_FileName, [], 0) ->
+    halt(0);
+print_issues(_FileName, [], _ErrCount) ->
+    halt(2);
+print_issues(FileName, [Issue | Issues], ErrCount) ->
+    Errs = print_issue(FileName, Issue),
+    print_issues(FileName, Issues, ErrCount + Errs).
 
 print_issue(FileName, {warning, Line, Description}) ->
-    io:format("~s:~p: warning: ~s~n", [FileName, Line, Description]);
+    io:format("~s:~p: warning: ~s~n", [FileName, Line, Description]),
+    0;
 print_issue(FileName, {error, Description}) ->
-    io:format("~s:~s~n", [FileName, Description]);
+    io:format("~s:~s~n", [FileName, Description]),
+    1;
 print_issue(FileName, {error, Line, Description}) ->
-    io:format("~s:~p: ~s~n", [FileName, Line, Description]).
+    io:format("~s:~p: ~s~n", [FileName, Line, Description]),
+    1.
 
 %% ===================================================================
 %% API


### PR DESCRIPTION
I'd expect utilities like this to exit with an error code when they found errors. Does this break the editor utils that use it?

* `0`: no errors (but maybe warnings)
* `1`: the user passed the `-h` flag
* `2`: there was at least one error