### PR TITLE
Rebar3 include location

### DIFF
--- a/src/syntaxerl_utils.erl
+++ b/src/syntaxerl_utils.erl
@@ -18,7 +18,7 @@ incls_deps_opts(FileName) ->
     AbsFileName = filename:absname(FileName),
     BaseDir = filename:dirname(filename:dirname(AbsFileName)),
 
-    StdOtpDirs = absdirs(BaseDir, ["./include", "./deps"]),
+    StdOtpDirs = absdirs(BaseDir, ["./include", "./deps", "./_build/default/lib"]),
     StdErlcOpts = [
         strong_validation,
 


### PR DESCRIPTION
rebar3 moves the build around a bit, and all the build related stuff is
now stored in `_build` including the fetched dependencies. Currently
this means that when using templates like for example for webmachine,
syntaxerl will not find the `hrl` files. Adding the path rebar3 works
with to the defaults fixes this and this work again. I think do to the
naming of `_build/default/lib` getting a false positive in pre rebar3
project is low enough to just add this as this.