### PR TITLE
test/test.sh: Use env(1) to find Bash

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 SYNTAXERL=${SCRIPT_DIR}/../syntaxerl


### PR DESCRIPTION
On some platforms, Bash in installed in other places than `/bin`. For example, on several BSDs, it's available as `/usr/local/bin/bash`.