### PR TITLE
Add support for ale (Asynchronous Lint Engine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,15 @@ Then add
 to your vimrc.
 
 Thanks [locojay](https://github.com/locojay) for that.
+
+#### ALE
+
+Install [ALE](https://github.com/w0rp/ale) plugin for vim 8+ or neovim.
+
+To disable erlc linter please add the following lines to your vimrc:
+
+```
+let g:ale_linters = {
+\   'erlang': ['syntaxerl'],
+\}
+```

--- a/src/check_syntax_spec.hrl
+++ b/src/check_syntax_spec.hrl
@@ -3,7 +3,7 @@
 
 -include("issues_spec.hrl").
 
--spec check_syntax(FileName::file:filename(), Debug::boolean()) ->
+-spec check_syntax(FileName::file:filename(), BaseFileName::file:filename(), Debug::boolean()) ->
     {ok, [warning() | error()]} | {error, [error()]}.
 
 -spec output_error(ErrorInfo::error_info()) -> boolean().

--- a/src/syntaxerl_erl.erl
+++ b/src/syntaxerl_erl.erl
@@ -4,7 +4,7 @@
 -behaviour(syntaxerl).
 
 -export([
-    check_syntax/2,
+    check_syntax/3,
     output_error/1,
     output_warning/1
 ]).
@@ -15,8 +15,8 @@
 %% API
 %% ===================================================================
 
-check_syntax(FileName, Debug) ->
-    {InclDirs, DepsDirs, ErlcOpts} = syntaxerl_utils:incls_deps_opts(FileName),
+check_syntax(FileName, BaseFileName, Debug) ->
+    {InclDirs, DepsDirs, ErlcOpts} = syntaxerl_utils:incls_deps_opts(BaseFileName),
     syntaxerl_logger:debug(Debug, "Include dirs: ~p", [InclDirs]),
     syntaxerl_logger:debug(Debug, "Deps dirs: ~p", [DepsDirs]),
     syntaxerl_logger:debug(Debug, "Erlc opts: ~p", [ErlcOpts]),

--- a/src/syntaxerl_escript.erl
+++ b/src/syntaxerl_escript.erl
@@ -18,16 +18,13 @@
 check_syntax(FileName, BaseFileName, Debug) ->
     case file:read_file(FileName) of
         {ok, Content} ->
-            ShebangRepl =
-                case re:run(Content, <<"-module">>) of
-                    {match, _} ->
-                        %% module attribute is defined. just remote shebang
-                        <<>>;
-                    nomatch ->
-                        %% replace shebang line with module attribute
-                        <<"-module(fixed_escript).">>
+            Preface = <<"-module(fixed_escript).\n-export([main/1]).\n">>,
+            NewContent =
+                case binary:split(Content, <<"\n">>) of
+                    [<<"#!", _/binary>>, Content0] ->
+                        <<Preface/binary, "\n", Content0/binary>>;
+                    _Other -> <<Preface/binary, Content/binary>>
                 end,
-            NewContent = re:replace(Content, <<"#.*">>, ShebangRepl),
             NewFileName = filename:rootname(FileName, ".erl") ++ "_fixed.erl",
             case file:write_file(NewFileName, NewContent) of
                 ok ->
@@ -47,13 +44,18 @@ check_syntax(FileName, BaseFileName, Debug) ->
                         {ok, _ModuleName} ->
                             {ok, []};
                         {ok, _ModuleName, Warnings} ->
-                            {ok, syntaxerl_format:format_warnings(?MODULE, Warnings)};
+                            io:format("Warnings: ~p~n", [Warnings]),
+                            {ok, syntaxerl_format:format_warnings(
+                                    ?MODULE, fix_line_numbers(Warnings))};
                         {error, Errors, Warnings} ->
-                            case syntaxerl_format:format_errors(?MODULE, Errors) of
+                            case syntaxerl_format:format_errors(
+                                    ?MODULE, fix_line_numbers(Errors)) of
                                 [] ->
-                                    {ok, syntaxerl_format:format_warnings(?MODULE, Warnings)};
+                                    {ok, syntaxerl_format:format_warnings(
+                                            ?MODULE, fix_line_numbers(Warnings))};
                                 Errors2 ->
-                                    {error, Errors2 ++ syntaxerl_format:format_warnings(?MODULE, Warnings)}
+                                    {error, Errors2 ++ syntaxerl_format:format_warnings(
+                                        ?MODULE, fix_line_numbers(Warnings))}
                             end
                     end;
                 {error, Reason} ->
@@ -66,3 +68,22 @@ check_syntax(FileName, BaseFileName, Debug) ->
 output_error(_) -> true.
 
 output_warning(_) -> true.
+
+%% ===================================================================
+%% Internal
+%% ===================================================================
+
+fix_line_numbers(ErrorList) ->
+    ErrorList0 = skip_expected_errors(ErrorList),
+    [{F, [{fix_line_number(L), M, E} || {L, M, E} <- Es]}
+     || {F, Es} <- ErrorList0].
+
+%% appropriately fix line numbers due to the `-module' definition.
+fix_line_number(none) -> 1;
+fix_line_number(Line) when Line < 3 -> 1;
+fix_line_number(Line) -> Line - 2.
+
+skip_expected_errors(ErrorList) ->
+    [{F, lists:keydelete(redefine_module, 3,
+         lists:keydelete({duplicated_export, {main, 1}}, 3, Es))}
+     || {F, Es} <- ErrorList].

--- a/src/syntaxerl_escript.erl
+++ b/src/syntaxerl_escript.erl
@@ -4,7 +4,7 @@
 -behaviour(syntaxerl).
 
 -export([
-    check_syntax/2,
+    check_syntax/3,
     output_error/1,
     output_warning/1
 ]).
@@ -15,7 +15,7 @@
 %% API
 %% ===================================================================
 
-check_syntax(FileName, Debug) ->
+check_syntax(FileName, BaseFileName, Debug) ->
     case file:read_file(FileName) of
         {ok, Content} ->
             ShebangRepl =
@@ -31,7 +31,7 @@ check_syntax(FileName, Debug) ->
             NewFileName = filename:rootname(FileName, ".erl") ++ "_fixed.erl",
             case file:write_file(NewFileName, NewContent) of
                 ok ->
-                    {InclDirs, DepsDirs, ErlcOpts} = syntaxerl_utils:incls_deps_opts(FileName),
+                    {InclDirs, DepsDirs, ErlcOpts} = syntaxerl_utils:incls_deps_opts(BaseFileName),
                     syntaxerl_logger:debug(Debug, "Include dirs: ~p", [InclDirs]),
                     syntaxerl_logger:debug(Debug, "Deps dirs: ~p", [DepsDirs]),
                     syntaxerl_logger:debug(Debug, "Erlc opts: ~p", [ErlcOpts]),

--- a/src/syntaxerl_hrl.erl
+++ b/src/syntaxerl_hrl.erl
@@ -4,10 +4,9 @@
 -behaviour(syntaxerl).
 
 -export([
-    check_syntax/2,
+    check_syntax/3,
     output_error/1,
     output_warning/1
-
 ]).
 
 -include("check_syntax_spec.hrl").
@@ -16,7 +15,7 @@
 %% API
 %% ===================================================================
 
-check_syntax(FileName, Debug) ->
+check_syntax(FileName, BaseFileName, Debug) ->
     case file:read_file(FileName) of
         {ok, Content} ->
             %% precede with the module name, so now this is a real erlang module.
@@ -28,7 +27,7 @@ check_syntax(FileName, Debug) ->
             NewFileName = FileName ++ ".erl",
             case file:write_file(NewFileName, NewContent) of
                 ok ->
-                    {InclDirs, DepsDirs, ErlcOpts} = syntaxerl_utils:incls_deps_opts(FileName),
+                    {InclDirs, DepsDirs, ErlcOpts} = syntaxerl_utils:incls_deps_opts(BaseFileName),
                     syntaxerl_logger:debug(Debug, "Include dirs: ~p", [InclDirs]),
                     syntaxerl_logger:debug(Debug, "Deps dirs: ~p", [DepsDirs]),
                     syntaxerl_logger:debug(Debug, "Erlc opts: ~p", [ErlcOpts]),

--- a/src/syntaxerl_script.erl
+++ b/src/syntaxerl_script.erl
@@ -4,7 +4,7 @@
 -behaviour(syntaxerl).
 
 -export([
-    check_syntax/2,
+    check_syntax/3,
     output_error/1,
     output_warning/1
 ]).
@@ -15,7 +15,7 @@
 %% API
 %% ===================================================================
 
-check_syntax(FileName, _Debug) ->
+check_syntax(FileName, _BaseFileName, _Debug) ->
     case syntaxerl_utils:consult_file(FileName) of
         {ok, _} ->
             {ok, []};

--- a/src/syntaxerl_terms.erl
+++ b/src/syntaxerl_terms.erl
@@ -4,7 +4,7 @@
 -behaviour(syntaxerl).
 
 -export([
-    check_syntax/2,
+    check_syntax/3,
     output_error/1,
     output_warning/1
 ]).
@@ -15,7 +15,7 @@
 %% API
 %% ===================================================================
 
-check_syntax(FileName, _Debug) ->
+check_syntax(FileName, _BaseFileName, _Debug) ->
     case file:eval(FileName) of
         ok ->
             {ok, []};

--- a/src/syntaxerl_xrl.erl
+++ b/src/syntaxerl_xrl.erl
@@ -4,7 +4,7 @@
 -behaviour(syntaxerl).
 
 -export([
-    check_syntax/2,
+    check_syntax/3,
     output_error/1,
     output_warning/1
 ]).
@@ -15,7 +15,7 @@
 %% API
 %% ===================================================================
 
-check_syntax(FileName, _Debug) ->
+check_syntax(FileName, _BaseFileName, _Debug) ->
     case leex:file(FileName, [{report, true}, {return, true}]) of
         {ok, ScannerFile} ->
             file:delete(ScannerFile),

--- a/src/syntaxerl_yrl.erl
+++ b/src/syntaxerl_yrl.erl
@@ -4,7 +4,7 @@
 -behaviour(syntaxerl).
 
 -export([
-    check_syntax/2,
+    check_syntax/3,
     output_error/1,
     output_warning/1
 ]).
@@ -15,7 +15,7 @@
 %% API
 %% ===================================================================
 
-check_syntax(FileName, _Debug) ->
+check_syntax(FileName, _BaseFileName, _Debug) ->
     case yecc:file(FileName, [{report, true}, {return, true}]) of
         {ok, ScannerFile} ->
             file:delete(ScannerFile),

--- a/test/escript_no_main.escript
+++ b/test/escript_no_main.escript
@@ -1,0 +1,6 @@
+#!/usr/bin/env escript
+
+-module(escript_no_main).
+
+main([]) ->
+    ok.

--- a/test/projects/rebar3-apps/_build/default/lib/lib2/src/src.erl
+++ b/test/projects/rebar3-apps/_build/default/lib/lib2/src/src.erl
@@ -1,0 +1,6 @@
+-module(src).
+
+-include_lib("lib1/include/lib1.hrl"). % _build/default/lib
+-include_lib("lib2/include/lib2.hrl"). % _build/test/lib
+-include_lib("lib3/include/lib3.hrl"). % _checkouts
+-include_lib("app2/include/app2.hrl").

--- a/test/projects/rebar3-apps/apps/app1/src/subdir/inc.hrl
+++ b/test/projects/rebar3-apps/apps/app1/src/subdir/inc.hrl
@@ -1,0 +1,1 @@
+%% Included

--- a/test/projects/rebar3-apps/apps/app1/src/subdir/subsrc.erl
+++ b/test/projects/rebar3-apps/apps/app1/src/subdir/subsrc.erl
@@ -1,0 +1,8 @@
+-module(subsrc).
+
+-include_lib("lib1/include/lib1.hrl"). % _build/default/lib
+-include_lib("lib2/include/lib2.hrl"). % _build/test/lib
+-include_lib("lib3/include/lib3.hrl"). % _checkouts
+-include_lib("app2/include/app2.hrl").
+-include("ext.hrl").
+-include("inc.hrl").

--- a/test/projects/rebar3-apps/apps/app1/src/types.erl
+++ b/test/projects/rebar3-apps/apps/app1/src/types.erl
@@ -1,0 +1,9 @@
+-module(types).
+
+-export_type([mydict/0]).
+
+-ifdef(namespaced_types).
+-type mydict() :: dict:dict().
+-else.
+-type mydict() :: dict().
+-endif.

--- a/test/projects/rebar3-apps/rebar.config
+++ b/test/projects/rebar3-apps/rebar.config
@@ -1,0 +1,1 @@
+{erl_opts, [{platform_define, "^[0-9]+", namespaced_types}]}.

--- a/test/test.sh
+++ b/test/test.sh
@@ -55,6 +55,8 @@ check escript_error.escript   code 1 w/ "escript_error.escript:7: function main/
 
 check escript_with_module_ok.escript code 0 w/ ""
 
+check escript_no_main.escript code 0 w/ ""
+
 check script_ok.script code 0 w/ ""
 check script_error.script code 1 w/ "{unbound_var,'ExtraDeps'}"
 
@@ -64,5 +66,8 @@ check terms_error.config code 1 w/ "terms_error.config:10: syntax error before: 
 check projects/default/src/src.erl code 0 w/ ""
 check projects/rebar-apps/apps/app1/src/src.erl code 0 w/ ""
 check projects/rebar3-apps/apps/app1/src/src.erl code 0 w/ ""
+check projects/rebar3-apps/apps/app1/src/subdir/subsrc.erl code 0 w/ ""
+check projects/rebar3-apps/_build/default/lib/lib2/src/src.erl code 0 w/ ""
+check projects/rebar3-apps/apps/app1/src/types.erl code 0 w/ ""
 
 exit ${EXIT}


### PR DESCRIPTION
ALE ([Asynchronous Lint Engine](https://github.com/w0rp/ale)) is the best linting engine for modern vim.  ALE makes use of NeoVim and Vim 8 job control functions and timers to run linters on the contents of text buffers and return errors as text is changed in Vim. This allows for displaying warnings and errors in files being edited in Vim before files have been saved back to a filesystem.

ALE saves current text buffer as a temporary file. I've added `--base` option to provide syntaxerl a path to original file. Also this patch contains several improvements for rebar3 and escript support.