### PR TITLE
Support escripts without extension

### DIFF
--- a/src/syntaxerl.app.src
+++ b/src/syntaxerl.app.src
@@ -12,6 +12,7 @@
         {[{suffix, ".escript"}]     , syntaxerl_escript},
         {[{suffix, ".es"}]          , syntaxerl_escript},
         {[{suffix, ".erl"}, shebang], syntaxerl_escript},
+        {[shebang]                  , syntaxerl_escript},
         {[{suffix, ".erl"}]         , syntaxerl_erl},
         {[{suffix, ".xrl"}]         , syntaxerl_xrl},
         {[{suffix, ".yrl"}]         , syntaxerl_yrl},

--- a/test/escript_error
+++ b/test/escript_error
@@ -1,0 +1,8 @@
+#!/usr/bin/env escript
+
+-export([main/1]).
+
+main([]) ->
+    no_arg.
+main([arg]) ->
+    arg.

--- a/test/escript_ok
+++ b/test/escript_ok
@@ -1,0 +1,9 @@
+#!/usr/bin/env escript
+
+-export([main/1]).
+
+-spec main(list()) -> no_return().
+main([]) ->
+    no_arg;
+main([arg]) ->
+    arg.

--- a/test/escript_warning
+++ b/test/escript_warning
@@ -1,0 +1,8 @@
+#!/usr/bin/env escript
+
+-export([main/1]).
+
+main([]) ->
+    no_arg;
+main([arg]) ->
+    arg.

--- a/test/test.sh
+++ b/test/test.sh
@@ -41,6 +41,10 @@ check hrl_ok.hrl      code 0 w/ ""
 check hrl_warning.hrl code 0 w/ "hrl_warning.hrl:4: warning: function test/0 is unused"
 check hrl_error.hrl   code 1 w/ "hrl_error.hrl:4: syntax error before: '}'"
 
+check escript_ok      code 0 w/ ""
+check escript_warning code 0 w/ "escript_warning:5: warning: missing specification for function main/1"
+check escript_error   code 1 w/ "escript_error:7: function main/1 already defined"
+
 check escript_ok.erl      code 0 w/ ""
 check escript_warning.erl code 0 w/ "escript_warning.erl:5: warning: missing specification for function main/1"
 check escript_error.erl   code 1 w/ "escript_error.erl:7: function main/1 already defined"


### PR DESCRIPTION
It would be useful to treat files with shebang and no extension as escripts.