### PR TITLE
Set error_location to line for OTP 24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ otp_release:
   - 19.3
   - 20.3
   - 21.3
+  - 22.3
+  - 23.3
+  - 24.1
 notifications:
   email:
     - dm.klionsky@gmail.com

--- a/src/syntaxerl_utils.erl
+++ b/src/syntaxerl_utils.erl
@@ -29,6 +29,11 @@ incls_deps_opts(FileName) ->
     ProjectDir = projectdir(AppDir),
     StdOtpDirs = include_dirs(AbsFileName, AppDir, ProjectDir),
     StdErlcOpts = [
+        %% Since OTP 24 compiler warnings and errors include column numbers in
+        %% addition to line numbers by default.  We are not ready for this yet.
+        %% The following option is ignored by older OTP releases.
+        {error_location, line},
+
         strong_validation,
 
         {warn_format, 1},


### PR DESCRIPTION
Since OTP 24 compiler warnings and errors include column numbers in
addition to line numbers by default.  This breaks error and warning
formatting.

It may be better to optionally include column numbers in output.  For
now, let's just keep the old behavior for the new OTP release.